### PR TITLE
feat(inbound): 增加对 BACKGROUND_JOB 事件的订阅控制

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-    Support JDK 1.8 / 17+
+    JDK 1.8 +
 
     Netty used 4.1.x, 5.x is not supported
 

--- a/freeswitch-esl-spring-boot-starter-example/src/main/resources/application.yml
+++ b/freeswitch-esl-spring-boot-starter-example/src/main/resources/application.yml
@@ -10,6 +10,8 @@ link:
             - host: 172.16.44.246
               port: 8021
               timeoutSeconds: 5
+            - host: 127.0.0.1
+              port: 8021
           events:
             - all
 #logging:

--- a/freeswitch-esl-spring-boot-starter/pom.xml
+++ b/freeswitch-esl-spring-boot-starter/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>freeswitch-esl</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/freeswitch-esl-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/freeswitch-esl-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+link.thingscloud.freeswitch.esl.spring.boot.starter.config.FreeswitchEslAutoConfiguration

--- a/freeswitch-esl/src/main/java/link/thingscloud/freeswitch/esl/InboundClient.java
+++ b/freeswitch-esl/src/main/java/link/thingscloud/freeswitch/esl/InboundClient.java
@@ -78,6 +78,13 @@ public interface InboundClient extends InboundClientService {
     InboundClientOption option();
 
     /**
+     * Whether to subscribe the BACKGROUND_JOB event
+     *
+     * @return subscribe BACKGROUND_JOB
+     */
+    boolean subscribeBackgroundJob();
+
+    /**
      * Sends a FreeSWITCH API command to the server and blocks, waiting for an immediate response from the
      * server.
      * <p>

--- a/freeswitch-esl/src/main/java/link/thingscloud/freeswitch/esl/inbound/AbstractInboundClient.java
+++ b/freeswitch-esl/src/main/java/link/thingscloud/freeswitch/esl/inbound/AbstractInboundClient.java
@@ -191,7 +191,7 @@ abstract class AbstractInboundClient extends AbstractNettyInboundClient implemen
                 start = System.currentTimeMillis();
             }
             if (option().eventPerformance()) {
-                long cost = 0L;
+                long cost;
                 if (start > 0L) {
                     cost = start - (event.getEventDateTimestamp() / 1000);
                 } else {

--- a/freeswitch-esl/src/main/java/link/thingscloud/freeswitch/esl/inbound/NettyInboundClient.java
+++ b/freeswitch-esl/src/main/java/link/thingscloud/freeswitch/esl/inbound/NettyInboundClient.java
@@ -17,6 +17,7 @@ package link.thingscloud.freeswitch.esl.inbound;
 
 import link.thingscloud.freeswitch.esl.InboundClient;
 import link.thingscloud.freeswitch.esl.constant.Constants;
+import link.thingscloud.freeswitch.esl.constant.EventNames;
 import link.thingscloud.freeswitch.esl.exception.InboundTimeoutExcetion;
 import link.thingscloud.freeswitch.esl.inbound.handler.InboundChannelHandler;
 import link.thingscloud.freeswitch.esl.inbound.option.InboundClientOption;
@@ -29,6 +30,9 @@ import link.thingscloud.freeswitch.esl.util.StringUtils;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static link.thingscloud.freeswitch.esl.constant.EventNames.ALL;
+import static link.thingscloud.freeswitch.esl.constant.EventNames.BACKGROUND_JOB;
+
 
 /**
  * <p>NettyInboundClient class.</p>
@@ -38,6 +42,8 @@ import java.util.function.Consumer;
  */
 public class NettyInboundClient extends AbstractInboundClient {
 
+    private volatile boolean subscribeBackgroundJob = false;
+
     /**
      * <p>Constructor for NettyInboundClient.</p>
      *
@@ -45,6 +51,11 @@ public class NettyInboundClient extends AbstractInboundClient {
      */
     public NettyInboundClient(InboundClientOption option) {
         super(option);
+    }
+
+    @Override
+    public boolean subscribeBackgroundJob() {
+        return subscribeBackgroundJob;
     }
 
     /**
@@ -132,6 +143,11 @@ public class NettyInboundClient extends AbstractInboundClient {
         }
         InboundChannelHandler handler = getAuthedHandler(addr);
 
+
+        if (StringUtils.contains(events, EventNames.BACKGROUND_JOB) || StringUtils.contains(events, EventNames.ALL)) {
+            subscribeBackgroundJob = true;
+        }
+
         StringBuilder sb = new StringBuilder();
         sb.append("event ");
         sb.append(format);
@@ -150,6 +166,7 @@ public class NettyInboundClient extends AbstractInboundClient {
     public CommandResponse cancelEventSubscriptions(String addr) {
         InboundChannelHandler handler = getAuthedHandler(addr);
         EslMessage response = handler.sendSyncSingleLineCommand("noevents");
+        subscribeBackgroundJob = false;
         return new CommandResponse("noevents", response);
     }
 


### PR DESCRIPTION
- 在 InboundClient 接口中添加 subscribeBackgroundJob 方法
- 在 NettyInboundClient 类中实现该方法，并根据事件订阅情况动态设置订阅状态
- 更新配置示例，添加新的 FreeSWITCH 地址
- 优化性能计算逻辑，移除不必要的变量初始化
- 更新 README，明确 JDK版本支持
- 添加 spring.factories 文件，支持 Spring Boot 自动配置